### PR TITLE
Fix 'valid' appearing as an action on message

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -137,7 +137,7 @@ function validate(lint, resolve) {
         let obj = yaml.parse(text);
         validator.validate(obj, options)
         .then(function(options){
-            vscode.window.showInformationMessage('Your OpenAPI document is:',lint ? 'excellent!' : 'valid.');
+            vscode.window.showInformationMessage('Your OpenAPI document is:' + (lint ? 'excellent!' : 'valid.'));
         })
 	    .catch(function(ex){
 	    	let message = 'Your OpenAPI document is not '+(options.valid ? 'perfect' : 'valid') + ' :( \n';


### PR DESCRIPTION
From the VSCode API: "Show an information message to users. Optionally provide an array of items which will be presented as clickable buttons."

How it currently appears:
![image](https://user-images.githubusercontent.com/36978885/60157330-d96b0600-9831-11e9-8f5a-f8b70b2ddbf6.png)
